### PR TITLE
add grid gap option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hexfriend",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -151,6 +151,12 @@ hexfiend red: #FF6666
 		resizeTo: window,
 	});
 
+	// Enable PixiJS dev tools in development
+	if (process.env.NODE_ENV == 'development') {
+		// @ts-ignore
+		globalThis.__PIXI_APP__ = app;
+	}
+
 	let showSavedMaps = false;
 
 	let saving = false;

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -431,6 +431,23 @@
 						renderGrid();
 					}}
 				/>
+				<label for="gridGap">Grid Gap</label>
+				<input
+					id="gap"
+					type="number"
+					min="0"
+					max="99"
+					bind:value={tfield.grid.gap}
+					on:focus={() => {
+						comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+					}}
+					on:change={() => {
+						redrawEntireMap();
+						comp_coordsLayer.updateAllCoordPositions();
+						if (retainIconPosition) comp_iconLayer.retainIconPositionOnHexResize(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+						comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+					}}
+				/>
 				<label for="gridColor">Grid Color</label>
 				<ColorInputPixi
 					bind:value={tfield.grid.stroke}
@@ -543,13 +560,13 @@
 				type="number"
 				bind:value={tfield.hexWidth}
 				on:focus={() => {
-					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight);
+					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 				}}
 				on:change={() => {
 					redrawEntireMap();
 					comp_coordsLayer.updateAllCoordPositions();
-					if (retainIconPosition) comp_iconLayer.retainIconPositionOnHexResize(tfield.hexWidth, tfield.hexHeight);
-					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight);
+					if (retainIconPosition) comp_iconLayer.retainIconPositionOnHexResize(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 				}}
 			/>
 
@@ -559,13 +576,13 @@
 				type="number"
 				bind:value={tfield.hexHeight}
 				on:focus={() => {
-					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight);
+					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 				}}
 				on:change={() => {
 					redrawEntireMap();
 					comp_coordsLayer.updateAllCoordPositions();
-					if (retainIconPosition) comp_iconLayer.retainIconPositionOnHexResize(tfield.hexWidth, tfield.hexHeight);
-					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight);
+					if (retainIconPosition) comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 				}}
 			/>
 

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -431,23 +431,7 @@
 						renderGrid();
 					}}
 				/>
-				<label for="gridGap">Grid Gap</label>
-				<input
-					id="gap"
-					type="number"
-					min="0"
-					max="99"
-					bind:value={tfield.grid.gap}
-					on:focus={() => {
-						comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
-					}}
-					on:change={() => {
-						redrawEntireMap();
-						comp_coordsLayer.updateAllCoordPositions();
-						if (retainIconPosition) comp_iconLayer.retainIconPositionOnHexResize(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
-						comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
-					}}
-				/>
+
 				<label for="gridColor">Grid Color</label>
 				<ColorInputPixi
 					bind:value={tfield.grid.stroke}
@@ -457,6 +441,24 @@
 					id={'gridColor'}
 				/>
 			{/if}
+
+			<label for="gridGap">Gap</label>
+			<input
+				id="gap"
+				type="number"
+				min="0"
+				max="99"
+				bind:value={tfield.grid.gap}
+				on:focus={() => {
+					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+				}}
+				on:change={() => {
+					redrawEntireMap();
+					comp_coordsLayer.updateAllCoordPositions();
+					if (retainIconPosition) comp_iconLayer.retainIconPositionOnHexResize(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+					comp_iconLayer.saveOldHexMeasurements(tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
+				}}
+			/>
 
 			<!-- LARGE HEXES -->
 			<label for="showOverlay">Large Hexes</label>
@@ -1014,6 +1016,12 @@
 		</h2>
 
 		<div id="changelog" class:hidden={hidden_settings.changelog}>
+			<p>Version 1.8.2</p>
+			<ul class="helperText">
+				<li>Added grid gap (thanks Evan!)</li>
+				<li>Save data update to version 8</li>
+			</ul>
+			
 			<p>Version 1.8.1</p>
 			<ul class="helperText">
 				<li>Added changelog</li>
@@ -1030,7 +1038,7 @@
 	<div class="setting-container">
 		<h2>About</h2>
 		<p class="helperText">
-			Hexfriend version 1.8.1 - "New stripes, Hexfriend"
+			Hexfriend version 1.8.2 - "New stripes, Hexfriend"
 		</p>
 		
 		<p class="helperText">

--- a/src/helpers/hexHelpers.ts
+++ b/src/helpers/hexHelpers.ts
@@ -17,8 +17,11 @@ export function getHexPath(
 	height: number,
 	orientation: hex_orientation = 'flatTop',
 	centerX: number = 0,
-	centerY: number = 0
+	centerY: number = 0,
+	gap: number = 0,
 ): number[] {
+	width += gap;
+	height += gap;
 	if (orientation == 'pointyTop') {
 		return [
 			centerX,
@@ -163,7 +166,9 @@ export function cube_round(frac: cube_coords): cube_coords {
 	return { q: q, r: r, s: s };
 }
 
-export function coords_worldToCube(worldX: number, worldY: number, hex_orientation: hex_orientation, hexWidth: number, hexHeight: number): cube_coords {
+export function coords_worldToCube(worldX: number, worldY: number, hex_orientation: hex_orientation, hexWidth: number, hexHeight: number, gridGap: number): cube_coords {
+	hexWidth += gridGap;
+	hexHeight += gridGap;
 	if (hex_orientation == 'flatTop') {
 		// This is the inversion of the axialToWorld
 		// Of course, substituting -q-r in as S
@@ -190,8 +195,11 @@ export function coords_cubeToWorld(
 	s: number,
 	hex_orientation: hex_orientation,
 	hexWidth: number,
-	hexHeight: number
+	hexHeight: number,
+	gridGap: number
 ): { x: number; y: number } {
+	hexWidth += gridGap;
+	hexHeight += gridGap;
 	if (hex_orientation == 'flatTop') {
 		let hx = q * hexWidth * 0.75;
 		let hy = (r * hexHeight) / 2 - (s * hexHeight) / 2;

--- a/src/layers/CoordsLayer.svelte
+++ b/src/layers/CoordsLayer.svelte
@@ -100,7 +100,7 @@
 		let text = coordTexts[hexId];
 
 		let idParts = breakDownHexID(hexId);
-		let newPos = coords_cubeToWorld(idParts.q, idParts.r, idParts.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight);
+		let newPos = coords_cubeToWorld(idParts.q, idParts.r, idParts.s, tfield.orientation, tfield.hexWidth + tfield.grid.gap, tfield.hexHeight + tfield.grid.gap);
 
 		text.pixiText.position.x = newPos.x;
 		text.pixiText.position.y = newPos.y + tfield.hexHeight / 2 - data_coordinates.gap;

--- a/src/layers/IconLayer.svelte
+++ b/src/layers/IconLayer.svelte
@@ -88,9 +88,9 @@
 
 		let scale: number;
 		if (tfield.hexWidth < tfield.hexHeight) {
-			scale = (tfield.hexWidth * (data_icon.pHex / 100)) / icon_texture_width;
+			scale = (tfield.hexWidth - tfield.grid.gap * (data_icon.pHex / 100)) / icon_texture_width;
 		} else {
-			scale = (tfield.hexHeight * (data_icon.pHex / 100)) / icon_texture_height;
+			scale = (tfield.hexHeight - tfield.grid.gap * (data_icon.pHex / 100)) / icon_texture_height;
 		}
 
 		return scale;
@@ -106,7 +106,8 @@
 				store_panning.curWorldY(),
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 			let iconCoords = coords_cubeToWorld(
 				clickedHexCoords.q,
@@ -114,7 +115,8 @@
 				clickedHexCoords.s,
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 			iconX = iconCoords.x;
 			iconY = iconCoords.y;
@@ -128,7 +130,7 @@
 	}
 
 	export function place_icon(icon: Icon, position: cube_coords) {
-		let icon_pos = coords_cubeToWorld(position.q, position.r, position.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight)
+		let icon_pos = coords_cubeToWorld(position.q, position.r, position.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap)
 
 		icons.push({ x: icon_pos.x, y: icon_pos.y, color: icon.color, scale: getIconScale(), id: iconId, texId: icon.texId });
 		iconId++;
@@ -188,7 +190,8 @@
 				store_panning.curWorldY(),
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 			let iconCoords = coords_cubeToWorld(
 				mouseHexCoords.q,
@@ -196,7 +199,8 @@
 				mouseHexCoords.s,
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 
 			iconX = iconCoords.x;
@@ -213,7 +217,8 @@
 				store_panning.curWorldY(),
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 			let iconCoords = coords_cubeToWorld(
 				mouseHexCoords.q,
@@ -221,7 +226,8 @@
 				mouseHexCoords.s,
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 
 			floatingIcon.x = iconCoords.x;
@@ -247,24 +253,27 @@
 
 	let oldHexWidth: number;
 	let oldHexHeight: number;
+	let oldGap: number;
 	// This is called during layer set up when maps are loaded, or when hex fields are focused on.
-	export function saveOldHexMeasurements(hexWidth: number, hexHeight: number) {
+	export function saveOldHexMeasurements(hexWidth: number, hexHeight: number, gap: number) {
 		oldHexWidth = hexWidth;
 		oldHexHeight = hexHeight;
+		oldGap = gap;
 	}
 
-	export function retainIconPositionOnHexResize(newHexWidth: number, newHexHeight: number) {
+	export function retainIconPositionOnHexResize(newHexWidth: number, newHexHeight: number, newGap: number) {
 		// Find proprtional horizontal and vertical distance from center of nearest hex, and retain the position with the new width and height
 
 		icons.forEach((icon: IconLayerIcon) => {
-			let closestHexCubeCoords = coords_worldToCube(icon.x, icon.y, tfield.orientation, oldHexWidth, oldHexHeight);
+			let closestHexCubeCoords = coords_worldToCube(icon.x, icon.y, tfield.orientation, oldHexWidth, oldHexHeight, tfield.grid.gap);
 			let closestHexPos = coords_cubeToWorld(
 				closestHexCubeCoords.q,
 				closestHexCubeCoords.r,
 				closestHexCubeCoords.s,
 				tfield.orientation,
 				oldHexWidth,
-				oldHexHeight
+				oldHexHeight,
+				oldGap,
 			);
 
 			let distanceFromHexLeft = oldHexWidth / 2 + icon.x - closestHexPos.x;
@@ -279,7 +288,8 @@
 				closestHexCubeCoords.s,
 				tfield.orientation,
 				newHexWidth,
-				newHexHeight
+				newHexHeight,
+				tfield.grid.gap,
 			);
 
 			icon.x = closestHexPosNew.x - newHexWidth / 2 + newHexWidth * proportionalHorizontalDistance;
@@ -312,14 +322,15 @@
 			let oldOrientation: hex_orientation = newOrientation == 'flatTop' ? 'pointyTop' : 'flatTop';
 
 			// Find the center coordinates of the hex the icon wants to stay in
-			let oldClosestHexCubeCoords = coords_worldToCube(icon.x, icon.y, oldOrientation, oldHexWidth, oldHexHeight);
+			let oldClosestHexCubeCoords = coords_worldToCube(icon.x, icon.y, oldOrientation, oldHexWidth, oldHexHeight, tfield.grid.gap);
 			let oldClosestHexPos = coords_cubeToWorld(
 				oldClosestHexCubeCoords.q,
 				oldClosestHexCubeCoords.r,
 				oldClosestHexCubeCoords.s,
 				oldOrientation,
 				oldHexWidth,
-				oldHexHeight
+				oldHexHeight,
+				tfield.grid.gap,
 			);
 
 			let distanceFromHexLeft = oldHexWidth / 2 + icon.x - oldClosestHexPos.x;
@@ -348,7 +359,8 @@
 				newHexCubeCoords.s,
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap,
 			);
 
 			// Adjust icon position to be the same amount left and down proportional to hex width and height as it was before the transformation
@@ -440,7 +452,8 @@
 				store_panning.curWorldY(),
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap
 			);
 			let iconCoords = coords_cubeToWorld(
 				mouseHexCoords.q,
@@ -448,7 +461,8 @@
 				mouseHexCoords.s,
 				tfield.orientation,
 				tfield.hexWidth,
-				tfield.hexHeight
+				tfield.hexHeight,
+				tfield.grid.gap
 			);
 
 			draggedIcon.x = iconCoords.x;

--- a/src/layers/LargeHexesLayer.svelte
+++ b/src/layers/LargeHexesLayer.svelte
@@ -76,7 +76,7 @@
 		for (let ring=0; ring<hexes_out; ring++) {
 			for (const hex_id of hex_helpers.getRing("0:0:0", ring)) {
 				let hex_coords = hex_helpers.id_to_coords(hex_id)
-				let big_hex_coords = hex_helpers.coords_cubeToWorld(hex_coords.q, hex_coords.r, hex_coords.s, tfield.orientation, big_width, big_height)
+				let big_hex_coords = hex_helpers.coords_cubeToWorld(hex_coords.q, hex_coords.r, hex_coords.s, tfield.orientation, big_width, big_height, tfield.grid.gap)
 
 				let hX = big_hex_coords.x+tfield.largehexes.offset.x*tfield.hexWidth
 				let hY =  big_hex_coords.y+tfield.largehexes.offset.y*tfield.hexHeight

--- a/src/layers/PathLayer.svelte
+++ b/src/layers/PathLayer.svelte
@@ -118,8 +118,8 @@
 		// Overlay a grid of smaller opposite orientation hexes and it lines up perfectly!
 
 		let snap_grid_orientation = tfield.orientation == hex_orientation.FLATTOP ? hex_orientation.POINTYTOP : hex_orientation.FLATTOP
-		let snap_grid_hexWidth = tfield.hexWidth / (tfield.orientation == hex_orientation.FLATTOP ? 2 : 1.5)
-		let snap_grid_hexHeight = tfield.hexHeight / (tfield.orientation == hex_orientation.FLATTOP ? 1.5 : 2)
+		let snap_grid_hexWidth = (tfield.hexWidth + tfield.grid.gap) / (tfield.orientation == hex_orientation.FLATTOP ? 2 : 1.5)
+		let snap_grid_hexHeight = (tfield.hexHeight + tfield.grid.gap) / (tfield.orientation == hex_orientation.FLATTOP ? 1.5 : 2)
 
 		let snap_coords = coords_worldToCube(
 			store_panning.curWorldX(),
@@ -127,6 +127,7 @@
 			snap_grid_orientation,
 			snap_grid_hexWidth,
 			snap_grid_hexHeight,
+			tfield.grid.gap,
 			)
 			
 		return coords_cubeToWorld(
@@ -136,6 +137,7 @@
 			snap_grid_orientation,
 			snap_grid_hexWidth,
 			snap_grid_hexHeight,
+			tfield.grid.gap,
 		)
 
 	}

--- a/src/layers/TerrainLayer.svelte
+++ b/src/layers/TerrainLayer.svelte
@@ -6,7 +6,8 @@
 	import type { TerrainHex, terrain_field } from '../types/terrain';
 	import type { Tile } from '../types/tilesets';
 	import type { TileSymbol } from '../types/tilesets';
-	import type { hex_id, tools } from '../types/toolData';
+	import type { hex_id } from '../types/toolData';
+	import { tools } from '../types/toolData'
 	import type CoordsLayer from './CoordsLayer.svelte';
 	
 	// Enums
@@ -225,15 +226,15 @@
 				square_moveAllHexesRight(amount);
 
 				if (tfield.orientation == 'flatTop') {
-					pan.offsetX -= tfield.hexWidth * 0.75 * pan.zoomScale * amount;
+					pan.offsetX -= (tfield.hexWidth + tfield.grid.gap) * 0.75 * pan.zoomScale * amount;
 
 					if (amount % 2 == 1) {
 						tfield.raised = tfield.raised == hex_raised.ODD ? hex_raised.EVEN : hex_raised.ODD;
 						square_updateRaisedColumn();
-						pan.offsetY += tfield.hexHeight * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale;
+						pan.offsetY += (tfield.hexHeight + tfield.grid.gap) * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale;
 					}
 				} else {
-					pan.offsetX -= tfield.hexWidth * pan.zoomScale * amount;
+					pan.offsetX -= (tfield.hexWidth + tfield.grid.gap) * pan.zoomScale * amount;
 				}
 
 				break;
@@ -247,14 +248,14 @@
 				square_moveAllHexesDown(amount);
 
 				if (tfield.orientation == 'flatTop') {
-					pan.offsetY -= tfield.hexHeight * pan.zoomScale * amount;
+					pan.offsetY -= (tfield.hexHeight + tfield.grid.gap) * pan.zoomScale * amount;
 				} else {
-					pan.offsetY -= tfield.hexHeight * 0.75 * pan.zoomScale * amount;
+					pan.offsetY -= (tfield.hexHeight + tfield.grid.gap) * 0.75 * pan.zoomScale * amount;
 
 					if (amount % 2 == 1) {
 						tfield.raised = tfield.raised == hex_raised.ODD ? hex_raised.EVEN : hex_raised.ODD;
 						square_changeIndentedRow();
-						pan.offsetX += tfield.hexWidth * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale;
+						pan.offsetX += (tfield.hexWidth + tfield.grid.gap) * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale;
 					}
 				}
 
@@ -370,10 +371,10 @@
 						square_updateRaisedColumn();
 					}
 
-					pan.offsetX += tfield.hexWidth * 0.75 * pan.zoomScale * amount;
-					pan.offsetY += tfield.hexHeight * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale * (amount % 2 == 0 ? 0 : 1);
+					pan.offsetX += (tfield.hexWidth + tfield.grid.gap) * 0.75 * pan.zoomScale * amount;
+					pan.offsetY += (tfield.hexHeight + tfield.grid.gap) * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale * (amount % 2 == 0 ? 0 : 1);
 				} else {
-					pan.offsetX += tfield.hexWidth * pan.zoomScale * amount;
+					pan.offsetX += (tfield.hexWidth + tfield.grid.gap) * pan.zoomScale * amount;
 				}
 
 				break;
@@ -400,7 +401,7 @@
 					if (amount % 2 == 1) {
 						tfield.raised = tfield.raised == 'odd' ? 'even' : 'odd';
 						square_changeIndentedRow();
-						pan.offsetX += tfield.hexWidth * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale;
+						pan.offsetX += (tfield.hexWidth + tfield.grid.gap) * 0.5 * (tfield.raised == 'odd' ? -1 : 1) * pan.zoomScale;
 					}
 				}
 
@@ -642,9 +643,9 @@
 		Object.keys(tfield.hexes).forEach((hexId: hex_id) => {
 			let hex = tfield.hexes[hexId];
 
-			let hexC = coords_cubeToWorld(hex.q, hex.r, hex.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.raised);
+			let hexC = coords_cubeToWorld(hex.q, hex.r, hex.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 
-			gridGraphics.drawPolygon(getHexPath(tfield.hexWidth, tfield.hexHeight, tfield.orientation, hexC.x, hexC.y));
+			gridGraphics.drawPolygon(getHexPath(tfield.hexWidth + tfield.grid.gap, tfield.hexHeight + tfield.grid.gap, tfield.orientation, hexC.x, hexC.y));
 		});
 	}
 
@@ -665,7 +666,7 @@
 
 	export function renderHex(hexId: hex_id) {
 		let hex = tfield.hexes[hexId];
-		let hexWorldCoords = coords_cubeToWorld(hex.q, hex.r, hex.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight);
+		let hexWorldCoords = coords_cubeToWorld(hex.q, hex.r, hex.s, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 
 		if (!hex.tile) {
 			terrainGraphics.beginFill(tfield.blankHexColor);
@@ -740,7 +741,7 @@
 		if (controls.mouseDown[0]) {
 			let x = store_panning.curWorldX();
 			let y = store_panning.curWorldY();
-			let clickedCoords = coords_worldToCube(x, y, tfield.orientation, tfield.hexWidth, tfield.hexHeight);
+			let clickedCoords = coords_worldToCube(x, y, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 
 			let clickedId = genHexId(clickedCoords.q, clickedCoords.r, clickedCoords.s);
 
@@ -824,7 +825,7 @@
 		if (controls.mouseDown[0]) {
 			let x = store_panning.curWorldX();
 			let y = store_panning.curWorldY();
-			let clickedCoords = coords_worldToCube(x, y, tfield.orientation, tfield.hexWidth, tfield.hexHeight);
+			let clickedCoords = coords_worldToCube(x, y, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 
 			let clickedId = genHexId(clickedCoords.q, clickedCoords.r, clickedCoords.s);
 
@@ -853,7 +854,8 @@
 			store_panning.curWorldY(),
 			tfield.orientation,
 			tfield.hexWidth,
-			tfield.hexHeight
+			tfield.hexHeight,
+			tfield.grid.gap
 		);
 
 		let clickedId = genHexId(clickedCoords.q, clickedCoords.r, clickedCoords.s);
@@ -871,7 +873,7 @@
 		
 		let x = store_panning.curWorldX();
 		let y = store_panning.curWorldY();
-		let clickedCoords = coords_worldToCube(x, y, tfield.orientation, tfield.hexWidth, tfield.hexHeight);
+		let clickedCoords = coords_worldToCube(x, y, tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap);
 
 		let clickedId = genHexId_coordsObj(clickedCoords);
 		if (!hexExists(clickedId)) return;
@@ -891,7 +893,7 @@
 		// Find all like hexes, much like a paintbucket, and perform a specific operation on them, passing in hex id as a parameter
 
 		let clickedId = genHexId_coordsObj(
-			coords_worldToCube(store_panning.curWorldX(), store_panning.curWorldY(), tfield.orientation, tfield.hexWidth, tfield.hexHeight)
+			coords_worldToCube(store_panning.curWorldX(), store_panning.curWorldY(), tfield.orientation, tfield.hexWidth, tfield.hexHeight, tfield.grid.gap)
 		);
 
 		if (!hexExists(clickedId)) return;

--- a/src/lib/defaultSaveData.ts
+++ b/src/lib/defaultSaveData.ts
@@ -28,7 +28,7 @@ let DEFAULTSAVEDATA: save_data = {
 
 		blankHexColor: 0xf2f2f2,
 
-		grid: { stroke: 0x333333, thickness: 1, shown: true },
+		grid: { stroke: 0x333333, thickness: 1, gap: 0, shown: true },
 
 		largehexes: {
 			shown: false,

--- a/src/lib/saveDataConverter.ts
+++ b/src/lib/saveDataConverter.ts
@@ -25,6 +25,15 @@ function convert_v6_to_v7(oldData: save_data): save_data {
 	return new_data;
 }
 
+function convert_v7_to_v8(old_data: save_data): save_data {
+	let new_data: save_data = JSON.parse(JSON.stringify(old_data))
+
+	new_data.TerrainField.grid.gap = 0
+
+	new_data.saveVersion = 8
+	return new_data;
+}
+
 export function convertSaveDataToLatest(oldData: save_data): save_data {
 	// Update to latest version
 	let newData: save_data = JSON.parse(JSON.stringify(oldData));
@@ -82,6 +91,7 @@ export function convertSaveDataToLatest(oldData: save_data): save_data {
 
 	newData = convert_v5_to_v6(newData);
 	newData = convert_v6_to_v7(newData);
+	newData = convert_v7_to_v8(newData);
 
 	return newData;
 }

--- a/src/stores/panning.ts
+++ b/src/stores/panning.ts
@@ -103,7 +103,7 @@ export const handlers = {
 
 			// controls how far you can zoom out (smaller number is farther out)
 			let minZoom = (window.innerWidth + window.innerHeight) / 2;
-			minZoom /= ((tfield.hexWidth + tfield.hexHeight) / 2) * ((calcColumns + calcRows) / 2) * 2;
+			minZoom /= ((tfield.hexWidth + tfield.hexHeight + tfield.grid.gap) / 2) * ((calcColumns + calcRows) / 2) * 2;
 			if (pan.zoomScale < minZoom) {
 				pan.zoomScale = minZoom;
 			}
@@ -111,7 +111,7 @@ export const handlers = {
 			let maxZoom = (window.innerWidth + window.innerHeight) / 2;
 			// TODO: use tile size
 			// maxZoom /= 100 * 2;
-			maxZoom /= ((tfield.hexWidth + tfield.hexHeight) / 2) * 4;
+			maxZoom /= ((tfield.hexWidth + tfield.hexHeight + tfield.grid.gap) / 2) * 4;
 			if (maxZoom < pan.zoomScale) {
 				pan.zoomScale = maxZoom;
 			}

--- a/src/types/savedata.ts
+++ b/src/types/savedata.ts
@@ -4,7 +4,7 @@ import type { path_style } from './path'
 import type { terrain_field } from './terrain';
 import type { Tileset } from './tilesets';
 
-const LATESTSAVEDATAVERSION = 7;
+const LATESTSAVEDATAVERSION = 8;
 const LATESTDEFAULTTILESVERSION = 4;
 const LATESTDEFAULTICONSVERSION = 5;
 

--- a/src/types/terrain.ts
+++ b/src/types/terrain.ts
@@ -27,7 +27,7 @@ export interface terrain_field {
 	hexWidth: number;
 	hexHeight: number;
 
-	grid: { stroke: number; thickness: number; shown: boolean };
+	grid: { stroke: number; thickness: number; gap: number; shown: boolean; };
 
 	mapShape: map_shape;
 	largehexes: {


### PR DESCRIPTION
I've never used svelte before, so I hope I didn't break anything.

Really love this hex editor, find it much easier to use than https://hextml.playest.net/

The only downside for me is that there wasn't a grid gap feature.

Having a grid-gap in the export eases cutting the individual hexes out after it's printed.

This way I can let my players discover one tile at a time.

🐭 

Here is an example,
![image](https://github.com/Aidymouse/Hexfriend/assets/17055832/b6d5872e-d068-4b8e-9d48-1531f722da22)

