### PR TITLE
Increase the resolution of PNG exports

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -164,6 +164,12 @@
 		resizeTo: window,
 	});
 
+	/* RENDERER FOR PNG EXPORT */
+	let hi_res_renderer = new PIXI.Renderer({
+		resolution: 3,
+		antialias: true
+	});
+
 	// Enable PixiJS dev tools in development
 	if (process.env.NODE_ENV == "development") {
 		// @ts-ignore
@@ -224,15 +230,18 @@
 
 		switch (exportType) {
 			case "image/png":
-				download(
-					await app.renderer.extract.base64(offsetContainer),
-					`${
-						loadedSave.title
-							? loadedSave.title
-							: "Untitled Hexfriend"
-					}`,
-					exportType,
-				);
+				hi_res_renderer.extract.canvas(offsetContainer)
+				.toBlob(function (blob) {
+					download(
+							blob,
+							`${
+									loadedSave.title
+											? loadedSave.title
+											: "Untitled Hexfriend"
+							}`,
+							exportType,
+					);
+				}, exportType);
 				break;
 
 			case "application/json":


### PR DESCRIPTION
A small change to increase the resolution of the PNG exports. Final result will change from this:

![Egion_low_res](https://github.com/Aidymouse/Hexfriend/assets/3295190/3248d4d0-6688-482c-bd3b-31a6ea92ecf6)

To this:

![Egion_hi_res|200](https://github.com/Aidymouse/Hexfriend/assets/3295190/b4dcbace-d09d-4865-afd2-417c76054d02)
